### PR TITLE
CIImage 모자이크 처리

### DIFF
--- a/Sources/HideOnImage/FilterType.swift
+++ b/Sources/HideOnImage/FilterType.swift
@@ -1,0 +1,16 @@
+//
+//  File.swift
+//  
+//
+//  Created by Jaehoon So on 2022/12/04.
+//
+
+import Foundation
+
+
+public enum FilterType: String {
+    // TODO: - 추후 추가적인 필터 추가
+    case CIGuassianFilter
+    case CISourceOverCompositing
+    case CIBlendWithMask
+}

--- a/Sources/HideOnImage/Mosaic+BlurProcess.swift
+++ b/Sources/HideOnImage/Mosaic+BlurProcess.swift
@@ -26,7 +26,7 @@ extension Mosaic {
 //        blurCompletionHandler?(UIImage(cgImage: cgImage))
 //    }
     
-    public func applyMosaic() {
+    public func applyMosaic(with faceRects: [CGRect]) {
         guard let image = self.currentImage,
               !detectBoundInfo.isEmpty else {
             // TODO: - 에러처리, 감지된 얼굴 없음 알림 등
@@ -34,12 +34,19 @@ extension Mosaic {
         }
         
         guard let ciImage = CIImage(image: image),
-              let mosaicImage = ciImage.gaussianBlur() else {
+              let mosaicImage = ciImage.gaussianBlur(),
+              let maskImage = ciImage.maskSelectedBound(detectBoundInfo),
+              let combinedImage = ciImage.combineMosaicAndMask(maskImage: maskImage, mosaicImage: mosaicImage),
+              let cgImage = Mosaic.context.createCGImage(
+                combinedImage,
+                from: combinedImage.extent
+              )
+        else {
             // TODO: - 이미지처리 실패 에러
             return
         }
         
-        let completeImage = UIImage(ciImage: mosaicImage)
+        let completeImage = UIImage(cgImage: cgImage)
         delegate?.MosaicImageProcessDidFinish(with: completeImage)
     }
     

--- a/Sources/HideOnImage/Mosaic.swift
+++ b/Sources/HideOnImage/Mosaic.swift
@@ -15,10 +15,10 @@ public final class Mosaic: MosaicProtocol {
     // MARK: - Properties
     public lazy var faceDetectionRequest: VNDetectFaceRectanglesRequest?
         = VNDetectFaceRectanglesRequest(completionHandler: handleDetectedFaces)
+    public static let context = CIContext()
     public var detectBoundInfo: [CGRect]
     public var currentImage: UIImage?
     public var delegate: MosaicDelegate?
-    
     
     // MARK: - Initializers
     public init() {


### PR DESCRIPTION
CIImage의 기본적인 모자이크 처리를 진행하였습니다.
모자이크 처리는 다음과 같은 과정을 통해서 처리됩니다.

<img width="400" src="https://user-images.githubusercontent.com/76734067/205482777-cc228d1f-30c5-4211-b6ba-9c7d5bec1efc.png">

- 이미지의 pixelate 된 버전을 생성한다.
- 얼굴을 탐지한 정보를 마탕으로 마스크를 생성한다.
- pixelate된 이미지와 모자이크 처리된 이미지를 마스크를 사용해서 처리해준다.

### Reference
- [Detecting Faces in an Image](https://developer.apple.com/library/archive/documentation/GraphicsImaging/Conceptual/CoreImaging/ci_detect_faces/ci_detect_faces.html#//apple_ref/doc/uid/TP30001185-CH8-SW1)
- [Anonymous Faces Filter Recipe](https://developer.apple.com/library/archive/documentation/GraphicsImaging/Conceptual/CoreImaging/ci_filer_recipes/ci_filter_recipes.html#//apple_ref/doc/uid/TP30001185-CH4-SW22)
